### PR TITLE
PHP 5.6 compatibility

### DIFF
--- a/code/cmb2_metatabs_options.php
+++ b/code/cmb2_metatabs_options.php
@@ -98,7 +98,7 @@ class Cmb2_Metatabs_Options {
 	 * @since 1.0.2  turned menuargs into array to match WP functions
 	 * @since 1.0.0
 	 */
-	private static $props = [];
+	private static $props = array();
 	
 	/**
 	 * Properties which can be injected via constructor, a subset of self::$props
@@ -109,14 +109,14 @@ class Cmb2_Metatabs_Options {
 	 * @since 1.1.1 added 'class'
 	 * @since 1.1.0 moved from self::$props to prevent problems with multiple options pages
 	 */
-	private $defaults = [
+	private $defaults = array(
 		'key'       => 'my_options',
 		'regkey'    => TRUE,
 		'title'     => 'My Options',
 		'topmenu'   => '',
 		'postslug'  => '',
 		'class'     => '',
-		'menuargs'  => [
+		'menuargs'  => array(
 			'parent_slug'     => '',
 			'page_title'      => '',
 			'menu_title'      => '',
@@ -126,18 +126,27 @@ class Cmb2_Metatabs_Options {
 			'position'        => NULL,
 			'network'         => FALSE,
 			'view_capability' => '',
-		],
+		),
 		'jsuri'     => '',
-		'boxes'     => [],
+		'boxes'     => array(),
 		'getboxes'  => TRUE,
 		'plugincss' => TRUE,
 		'admincss'  => '',
-		'tabs'      => [],
+		'tabs'      => array(),
 		'cols'      => 1,
 		'resettxt'  => 'Reset',
 		'savetxt'   => 'Save',
-		'load'      => [],
-	];
+		'load'      => array(),
+	);
+
+	/**
+	 * Auto-generated object ID
+	 *
+	 * @var string
+	 *
+	 * @since  1.3.1
+	 */
+	protected $id;
 	
 	/**
 	 * Inject anything within the self::$defaults array by matching the argument keys.
@@ -167,24 +176,24 @@ class Cmb2_Metatabs_Options {
 		}
 		
 		// set the ID
-		$id = $this->set_ID();
+		$this->id = $this->set_ID();
 		
 		// parse any injected arguments and add to self::$props
-		self::$props[ $id ] = $this->parse_args_r( $args, $this->defaults );
+		self::$props[ $this->id ] = $this->parse_args_r( $args, $this->defaults );
 		
 		// validate the properties we were sent
-		$this->validate_props( $id );
+		$this->validate_props( $this->id );
 		
 		// if the menu_slug == parent_slug, set hide to true, prevents duplicate page display
-		self::$props[ $id ]['hide'] =
-			self::$props[ $id ]['menuargs']['parent_slug'] == self::$props[ $id ]['menuargs']['menu_slug'] &&
-			self::$props[ $id ]['menuargs']['parent_slug'] != '';
+		self::$props[ $this->id ]['hide'] =
+			self::$props[ $this->id ]['menuargs']['parent_slug'] == self::$props[ $this->id ]['menuargs']['menu_slug'] &&
+			self::$props[ $this->id ]['menuargs']['parent_slug'] != '';
 		
 		// add tabs: several actions depend on knowing if tabs are present
-		self::$props[ $id ]['tabs'] = $this->add_tabs( $id );
+		self::$props[ $this->id ]['tabs'] = $this->add_tabs();
 		
 		// Add actions
-		$this->add_wp_actions( $id );
+		$this->add_wp_actions();
 	}
 	
 	/**
@@ -231,128 +240,109 @@ class Cmb2_Metatabs_Options {
 	/**
 	 * Checks the values of critical passed properties
 	 *
-	 * @param string $id @since 1.1.0
+	 * @param string $this->id @since 1.1.0
 	 *
 	 * @throws \Exception
 	 *
 	 * @since 1.2   Added view_capability setting
-	 * @since 1.1.0 Setting self::$props[$id][page]
+	 * @since 1.1.0 Setting self::$props[$this->id][page]
 	 * @since 1.0.2 Removed validation of menu args. Sending a plain array will no longer work!
 	 * @since 1.0.1 Moved menuargs validation to within this method
 	 * @since 1.0.0
 	 */
-	private function validate_props( $id ) {
+	private function validate_props() {
 		
 		// if key or title do not exist, throw exception
-		if ( ! self::$props[ $id ]['key'] ) {
+		if ( ! self::$props[ $this->id ]['key'] ) {
 			throw new Exception( 'CMB2_Metatabs_Options: Settings key missing.' );
 		}
 		
 		// set JS url
-		if ( ! self::$props[ $id ]['jsuri'] ) {
-			self::$props[ $id ]['jsuri'] = plugin_dir_url( __FILE__ ) . 'cmb2multiopts.js';
+		if ( ! self::$props[ $this->id ]['jsuri'] ) {
+			self::$props[ $this->id ]['jsuri'] = plugin_dir_url( __FILE__ ) . 'cmb2multiopts.js';
 		}
 		
 		// set columns to 1 if illegal value sent
-		self::$props[ $id ]['cols'] = intval( self::$props[ $id ]['cols'] );
-		if ( self::$props[ $id ]['cols'] > 2 || self::$props[ $id ]['cols'] < 1 ) {
-			self::$props[ $id ]['cols'] = 1;
+		self::$props[ $this->id ]['cols'] = intval( self::$props[ $this->id ]['cols'] );
+		if ( self::$props[ $this->id ]['cols'] > 2 || self::$props[ $this->id ]['cols'] < 1 ) {
+			self::$props[ $this->id ]['cols'] = 1;
 		}
 		
 		// if menuargs[menu_slug] is set, change the page prop to that
-		self::$props[ $id ]['page'] = self::$props[ $id ]['menuargs']['menu_slug'] ?
-			self::$props[ $id ]['menuargs']['menu_slug'] : self::$props[ $id ]['key'];
+		self::$props[ $this->id ]['page'] = self::$props[ $this->id ]['menuargs']['menu_slug'] ?
+			self::$props[ $this->id ]['menuargs']['menu_slug'] : self::$props[ $this->id ]['key'];
 		
 		// set page viewing capability; empty string = same as menuargs[capability], false = do not check
-		if ( ! self::$props[ $id ]['menuargs']['view_capability'] ) {
-			self::$props[ $id ]['menuargs']['view_capability'] =
-				self::$props[ $id ]['menuargs']['view_capability'] === '' ?
-					self::$props[ $id ]['menuargs']['capability'] : FALSE;
+		if ( ! self::$props[ $this->id ]['menuargs']['view_capability'] ) {
+			self::$props[ $this->id ]['menuargs']['view_capability'] =
+				self::$props[ $this->id ]['menuargs']['view_capability'] === '' ?
+					self::$props[ $this->id ]['menuargs']['capability'] : FALSE;
 		}
 	}
 	
 	/**
 	 * Some additional actions are added elsewhere as they cannot be added this early.
 	 *
-	 * @param string $id @since 1.1.0
+	 * @param string $this->id @since 1.1.0
 	 *
 	 * @since 1.1.0 menu can be added to multisite network menu
 	 *              - page load actions allowed
 	 *              - registering the options key optional
 	 * @since 1.0.0
 	 */
-	private function add_wp_actions( $id ) {
+	private function add_wp_actions() {
 		
 		// Register setting
-		if ( self::$props[ $id ]['regkey'] ) {
+		if ( self::$props[ $this->id ]['regkey'] ) {
 			add_action(
 				'admin_init',
-				function () use ( $id ) {
-					
-					$this->register_setting( $id );
-				}
+				array( $this, 'register_setting' )
 			);
 		}
 		
 		// Allow multisite network menu pages
-		$net = ( is_multisite() && self::$props[ $id ]['menuargs']['network'] === TRUE ) ? 'network_' : '';
+		$net = ( is_multisite() && self::$props[ $this->id ]['menuargs']['network'] === TRUE ) ? 'network_' : '';
 		
 		// Adds page to admin
 		add_action(
 			$net . 'admin_menu',
-			function () use ( $id ) {
-				
-				$this->add_options_page( $id );
-			},
+			array( $this, 'add_options_page' ),
 			12
 		);
 		
 		// Include CSS for this options page as style tag in head, if tabs are configured
 		add_action(
 			'admin_head',
-			function () use ( $id ) {
-				
-				$this->add_css( $id );
-			}
+			array( $this, 'add_css' )
 		);
 		
 		// Adds JS to foot
 		add_action(
 			'admin_enqueue_scripts',
-			function () use ( $id ) {
-				
-				$this->add_scripts( $id );
-			}
+			array( $this, 'add_scripts' )
 		);
 		
 		// Adds custom save button field, allowing save button to be added to metaboxes
 		add_action(
 			'cmb2_render_options_save_button',
-			function () use ( $id ) {
-				
-				global $hook_suffix;
-				if ( $hook_suffix !== self::$props[ $id ]['hook'] || self::$props[ $id ]['hide'] ) {
-					return;
-				}
-				$args = func_get_args();
-				echo $this->render_save_button( $args[0]->args['desc'] );
-			}, 10, 1 );
+			array( $this, 'render_options_save_button' ),
+			10, 1 );
 	}
 	
 	/**
 	 * Allows page to call WP actions on load
 	 *
-	 * @param string $id
+	 * @param string $this->id
 	 *
 	 * @since 1.1.0
 	 */
-	private function load_actions( $id ) {
+	private function load_actions() {
 		
-		if ( empty( self::$props[ $id ]['load'] ) ) {
+		if ( empty( self::$props[ $this->id ]['load'] ) ) {
 			return;
 		}
 		
-		foreach ( self::$props[ $id ]['load'] as $load ) {
+		foreach ( self::$props[ $this->id ]['load'] as $load ) {
 			
 			// skip if no action or callback
 			if ( ! isset( $load['action'] ) || ! isset( $load['callback'] ) ) {
@@ -365,7 +355,7 @@ class Cmb2_Metatabs_Options {
 			}
 			
 			// replace token with page hook
-			$load['action'] = str_replace( '[hook]', self::$props[ $id ]['hook'], $load['action'] );
+			$load['action'] = str_replace( '[hook]', self::$props[ $this->id ]['hook'], $load['action'] );
 			
 			// make sure if priority is int
 			$pri = isset( $load['priority'] ) && intval( $load['priority'] ) > 0 ? intval( $load['priority'] ) : 10;
@@ -379,58 +369,52 @@ class Cmb2_Metatabs_Options {
 	}
 	
 	/**
-	 * @param string $id @since 1.1.0
+	 * @param string $this->id @since 1.1.0
 	 *
 	 * @since 1.0.0
 	 */
-	public function register_setting( $id ) {
+	public function register_setting() {
 		
-		register_setting( self::$props[ $id ]['key'], self::$props[ $id ]['key'] );
+		register_setting( self::$props[ $this->id ]['key'], self::$props[ $this->id ]['key'] );
 	}
 	
 	/**
-	 * @param string $id @since 1.1.0
+	 * @param string $this->id @since 1.1.0
 	 *
 	 * @since 1.1.0 Changed some action callbacks to closures
 	 *              - pages can now load actions
 	 * @since 1.0.2 Moved the callback determination to build_menu_args()
 	 * @since 1.0.0
 	 */
-	public function add_options_page( $id ) {
+	public function add_options_page() {
 		
 		// build arguments
-		$args = $this->build_menu_args( $id );
+		$args = $this->build_menu_args( $this->id );
 		
 		// this is kind of ugly, but so is the WP function!
-		self::$props[ $id ]['hook'] =
+		self::$props[ $this->id ]['hook'] =
 			$args['cb']( $args[0], $args[1], $args[2], $args[3], $args[4], $args[5], $args[6] );
 		
 		// Include CMB CSS in the head to avoid FOUC, called here as we need the screen ID
 		add_action(
-			'admin_print_styles-' . self::$props[ $id ]['hook'],
-			[ 'CMB2_hookup', 'enqueue_cmb_css' ]
+			'admin_print_styles-' . self::$props[ $this->id ]['hook'],
+			array( 'CMB2_hookup', 'enqueue_cmb_css' )
 		);
 		
 		// Adds existing metaboxes, see note in function, called here as we need the screen ID
 		add_action(
-			'add_meta_boxes_' . self::$props[ $id ]['hook'],
-			function () use ( $id ) {
-				
-				$this->add_metaboxes( $id );
-			}
+			'add_meta_boxes_' . self::$props[ $this->id ]['hook'],
+			array( $this, 'add_metaboxes' )
 		);
 		
 		// On page load, do "metaboxes" actions, called here as we need the screen ID
 		add_action(
-			'load-' . self::$props[ $id ]['hook'],
-			function () use ( $id ) {
-				
-				$this->do_metaboxes( $id );
-			}
+			'load-' . self::$props[ $this->id ]['hook'],
+			array( $this, 'do_metaboxes' )
 		);
 		
 		// Allows pages to call actions
-		$this->load_actions( $id );
+		$this->load_actions();
 	}
 	
 	/**
@@ -439,7 +423,7 @@ class Cmb2_Metatabs_Options {
 	 * Including either self::$props['topmenu'] or self::$props['menuargs']['parent_slug'] will trigger the creation
 	 * of a submenu, otherwise a new top menu will be added.
 	 *
-	 * @param string $id @since 1.1.0
+	 * @param string $this->id @since 1.1.0
 	 *
 	 * @return array
 	 *
@@ -447,23 +431,23 @@ class Cmb2_Metatabs_Options {
 	 * @since 1.0.1 Removed menuargs validation to validate_props() method
 	 * @since 1.0.0
 	 */
-	private function build_menu_args( $id ) {
+	private function build_menu_args() {
 		
-		$args = [];
+		$args = array();
 		
 		// set the top menu if either topmenu or the menuargs parent_slug is set
-		$parent = self::$props[ $id ]['topmenu'] ? self::$props[ $id ]['topmenu'] : '';
-		$parent = self::$props[ $id ]['menuargs']['parent_slug'] ?
-			self::$props[ $id ]['menuargs']['parent_slug'] : $parent;
+		$parent = self::$props[ $this->id ]['topmenu'] ? self::$props[ $this->id ]['topmenu'] : '';
+		$parent = self::$props[ $this->id ]['menuargs']['parent_slug'] ?
+			self::$props[ $this->id ]['menuargs']['parent_slug'] : $parent;
 		
 		// set the page title; overrides 'title' with menuargs 'page_title' if set
-		$pagetitle = self::$props[ $id ]['menuargs']['page_title'] ?
-			self::$props[ $id ]['menuargs']['page_title'] : self::$props[ $id ]['title'];
+		$pagetitle = self::$props[ $this->id ]['menuargs']['page_title'] ?
+			self::$props[ $this->id ]['menuargs']['page_title'] : self::$props[ $this->id ]['title'];
 		
 		// sub[0] : parent slug
 		if ( $parent ) {
 			// add a post_type get variable, to allow post options pages, if set
-			$add    = self::$props[ $id ]['postslug'] ? '?post_type=' . self::$props[ $id ]['postslug'] : '';
+			$add    = self::$props[ $this->id ]['postslug'] ? '?post_type=' . self::$props[ $this->id ]['postslug'] : '';
 			$args[] = $parent . $add;
 		}
 		
@@ -471,32 +455,29 @@ class Cmb2_Metatabs_Options {
 		$args[] = $pagetitle;
 		
 		// top[1], sub[2] : menu title, defaults to page title if not set
-		$args[] = self::$props[ $id ]['menuargs']['menu_title'] ?
-			self::$props[ $id ]['menuargs']['menu_title'] : $pagetitle;
+		$args[] = self::$props[ $this->id ]['menuargs']['menu_title'] ?
+			self::$props[ $this->id ]['menuargs']['menu_title'] : $pagetitle;
 		
 		// top[2], sub[3] : capability
-		$args[] = self::$props[ $id ]['menuargs']['capability'];
+		$args[] = self::$props[ $this->id ]['menuargs']['capability'];
 		
 		// top[3], sub[4] : menu_slug, defaults to options slug if not set
-		$args[] = self::$props[ $id ]['menuargs']['menu_slug'] ?
-			self::$props[ $id ]['menuargs']['menu_slug'] : self::$props[ $id ]['key'];
+		$args[] = self::$props[ $this->id ]['menuargs']['menu_slug'] ?
+			self::$props[ $this->id ]['menuargs']['menu_slug'] : self::$props[ $this->id ]['key'];
 		
 		// top[4], sub[5] : callable function
-		$args[] = function () use ( $id ) {
-			
-			$this->admin_page_display( $id );
-		};
+		$args[] = array( $this, 'admin_page_display' );
 		
 		// top menu icon and menu position
 		if ( ! $parent ) {
 			
 			// top[5] icon url
-			$args[] = self::$props[ $id ]['menuargs']['icon_url'] ?
-				self::$props[ $id ]['menuargs']['icon_url'] : '';
+			$args[] = self::$props[ $this->id ]['menuargs']['icon_url'] ?
+				self::$props[ $this->id ]['menuargs']['icon_url'] : '';
 			
 			// top[6] menu position
-			$args[] = self::$props[ $id ]['menuargs']['position'] === NULL ?
-				NULL : intval( self::$props[ $id ]['menuargs']['position'] );
+			$args[] = self::$props[ $this->id ]['menuargs']['position'] === NULL ?
+				NULL : intval( self::$props[ $this->id ]['menuargs']['position'] );
 		} // sub[6] : unused, but returns consistent array
 		else {
 			$args[] = NULL;
@@ -512,7 +493,7 @@ class Cmb2_Metatabs_Options {
 	 * Add WP's metabox script, either by itself or as dependency of the tabs script. Added only to this options page.
 	 * If you roll your own script, note the localized values being passed here.
 	 *
-	 * @param string $id @since 1.1.0
+	 * @param string $this->id @since 1.1.0
 	 *
 	 * @throws \Exception
 	 *
@@ -521,12 +502,12 @@ class Cmb2_Metatabs_Options {
 	 * @since 1.0.1 Always add postbox toggle, removed toggle from tab handler JS
 	 * @since 1.0.0
 	 */
-	public function add_scripts( $id ) {
+	public function add_scripts() {
 		
 		global $hook_suffix;
 		
 		// do not run if not a CMO page
-		if ( $hook_suffix !== self::$props[ $id ]['hook'] ) {
+		if ( $hook_suffix !== self::$props[ $this->id ]['hook'] ) {
 			return;
 		}
 		
@@ -536,40 +517,51 @@ class Cmb2_Metatabs_Options {
 		// toggle the postboxes
 		add_action(
 			'admin_print_footer_scripts',
-			[ $this, 'toggle_postboxes' ]
+			array( $this, 'toggle_postboxes' )
 		);
 		
 		// only add the main script to the options page if there are tabs present
-		if ( empty( self::$props[ $id ]['tabs'] ) ) {
+		if ( empty( self::$props[ $this->id ]['tabs'] ) ) {
 			return;
 		}
 		
 		// if self::$props['jsuri'] is empty, throw exception
-		if ( ! self::$props[ $id ]['jsuri'] ) {
+		if ( ! self::$props[ $this->id ]['jsuri'] ) {
 			throw new Exception( 'CMB2_Metatabs_Options: Tabs included but JS file not specified.' );
 		}
 		
 		// check to see if file exists, throws exception if it does not
-		$headers = @get_headers( self::$props[ $id ]['jsuri'] );
+		$headers = @get_headers( self::$props[ $this->id ]['jsuri'] );
 		if ( $headers[0] == 'HTTP/1.1 404 Not Found' ) {
 			throw new Exception( 'CMB2_Metatabs_Options: Passed Javascript file missing.' );
 		}
 		
 		// enqueue the script
 		wp_enqueue_script(
-			self::$props[ $id ]['page'] . '-admin',
-			self::$props[ $id ]['jsuri'],
-			[ 'postbox' ],
+			self::$props[ $this->id ]['page'] . '-admin',
+			self::$props[ $this->id ]['jsuri'],
+			array( 'postbox' ),
 			FALSE,
 			TRUE
 		);
 		
 		// localize script to give access to this page's slug
-		wp_localize_script( self::$props[ $id ]['page'] . '-admin', 'cmb2OptTabs', [
-			'key'        => self::$props[ $id ]['page'],
-			'posttype'   => self::$props[ $id ]['postslug'],
-			'defaulttab' => self::$props[ $id ]['tabs'][0]['id'],
-		] );
+		wp_localize_script( self::$props[ $this->id ]['page'] . '-admin', 'cmb2OptTabs', array(
+			'key'        => self::$props[ $this->id ]['page'],
+			'posttype'   => self::$props[ $this->id ]['postslug'],
+			'defaulttab' => self::$props[ $this->id ]['tabs'][0]['id'],
+		) );
+	}
+
+	public function render_options_save_button() {
+		global $hook_suffix;
+
+		if ( $hook_suffix !== self::$props[ $this->id ]['hook'] || self::$props[ $this->id ]['hide'] ) {
+			return;
+		}
+
+		$args = func_get_args();
+		echo $this->render_save_button( $args[0]->args['desc'] );
 	}
 	
 	/**
@@ -585,7 +577,7 @@ class Cmb2_Metatabs_Options {
 	/**
 	 * Adds a couple of rules to clean up WP styles if tabs are included
 	 *
-	 * @param string $id @since 1.1.0
+	 * @param string $this->id @since 1.1.0
 	 *
 	 * @since 1.2   checks 'plugincss' and does not add plugincss if set to false
 	 * @since 1.1.1 added check of 'admincss' option to allow user to not add these styles
@@ -593,28 +585,28 @@ class Cmb2_Metatabs_Options {
 	 *              added IDs to style tags
 	 * @since 1.0.0
 	 */
-	public function add_css( $id ) {
+	public function add_css() {
 		
 		// if tabs are not being used, return
-		if ( empty( self::$props[ $id ]['tabs'] ) || self::$props[ $id ]['admincss'] === FALSE ) {
+		if ( empty( self::$props[ $this->id ]['tabs'] ) || self::$props[ $this->id ]['admincss'] === FALSE ) {
 			return;
 		}
 		
 		$css = '';
 		
 		// add css to clean up tab styles in admin when used in a postbox
-		if ( self::$props[ $id ]['plugincss'] === TRUE ) {
+		if ( self::$props[ $this->id ]['plugincss'] === TRUE ) {
 			$css .= '<style type="text/css" id="CMO-cleanup-css">';
-			$css .= '.' . self::$props[ $id ]['page'] . '.cmb2-options-page #poststuff h2.nav-tab-wrapper{padding-bottom:0;margin-bottom: 20px;}';
-			$css .= '.' . self::$props[ $id ]['page'] . '.cmb2-options-page .opt-hidden{display:none;}';
-			$css .= '.' . self::$props[ $id ]['page'] . '.cmb2-options-page #side-sortables{padding-top:22px;}';
+			$css .= '.' . self::$props[ $this->id ]['page'] . '.cmb2-options-page #poststuff h2.nav-tab-wrapper{padding-bottom:0;margin-bottom: 20px;}';
+			$css .= '.' . self::$props[ $this->id ]['page'] . '.cmb2-options-page .opt-hidden{display:none;}';
+			$css .= '.' . self::$props[ $this->id ]['page'] . '.cmb2-options-page #side-sortables{padding-top:22px;}';
 			$css .= '</style>';
 		}
 		
 		// add user-injected CSS; added as separate style tag in case it is malformed
-		if ( ! empty( self::$props[ $id ]['admincss'] ) ) {
+		if ( ! empty( self::$props[ $this->id ]['admincss'] ) ) {
 			$css = '<style type="text/css" id="CMO-exta-css">';
-			$css .= self::$props[ $id ]['admincss'];
+			$css .= self::$props[ $this->id ]['admincss'];
 			$css .= '</style>';
 		}
 		
@@ -624,26 +616,24 @@ class Cmb2_Metatabs_Options {
 	/**
 	 * Adds CMB2 metaboxes.
 	 *
-	 * @param string $id @since 1.1.0
-	 *
 	 * @since 1.1.0  ok to have no metaboxes (to allow text-only pages)
 	 *               - some action callbacks now closures
 	 * @since 1.0.0
 	 */
-	public function add_metaboxes( $id ) {
+	public function add_metaboxes() {
 		
 		// get the metaboxes
-		self::$props[ $id ]['boxes'] = $this->cmb2_metaboxes( $id );
+		self::$props[ $this->id ]['boxes'] = $this->cmb2_metaboxes( $this->id );
 		
 		// exit this method if no metaboxes are present
-		if ( empty( self::$props[ $id ]['boxes'] ) ) {
+		if ( empty( self::$props[ $this->id ]['boxes'] ) ) {
 			return;
 		}
 		
-		foreach ( self::$props[ $id ]['boxes'] as $box ) {
+		foreach ( self::$props[ $this->id ]['boxes'] as $box ) {
 			
 			// skip if this should not be shown
-			if ( ! $this->should_show( $box, $id ) ) {
+			if ( ! $this->should_show( $box, $this->id ) ) {
 				continue;
 			}
 			
@@ -651,32 +641,27 @@ class Cmb2_Metatabs_Options {
 			
 			// add notice if settings are saved
 			add_action( 'cmb2_save_options-page_fields_' . $mid,
-				function () use ( $id ) {
-					
-					$this->settings_notices( func_get_args(), $id );
-				}, 10, 2 );
+				array( $this, 'settings_notices' ),
+				10, 2 );
 			
 			// add callback if tabs are configured which hides metaboxes until moved into proper tabs if not in sidebar
-			if ( ! empty( self::$props[ $id ]['tabs'] ) && $box->meta_box['context'] !== 'side' ) {
-				add_filter( 'postbox_classes_' . self::$props[ $id ]['hook'] . '_' . $mid,
-					[ $this, 'hide_metabox_class' ] );
+			if ( ! empty( self::$props[ $this->id ]['tabs'] ) && $box->meta_box['context'] !== 'side' ) {
+				add_filter( 'postbox_classes_' . self::$props[ $this->id ]['hook'] . '_' . $mid,
+					array( $this, 'hide_metabox_class' ) );
 			}
 			
 			// if boxes are closed by default...
 			if ( $box->meta_box['closed'] ) {
-				add_filter( 'postbox_classes_' . self::$props[ $id ]['hook'] . '_' . $mid,
-					[ $this, 'close_metabox_class' ] );
+				add_filter( 'postbox_classes_' . self::$props[ $this->id ]['hook'] . '_' . $mid,
+					array( $this, 'close_metabox_class' ) );
 			}
 			
 			// add meta box
 			add_meta_box(
 				$box->meta_box['id'],
 				$box->meta_box['title'],
-				function () use ( $id ) {
-					
-					$this->metabox_callback( func_get_args(), $id );
-				},
-				self::$props[ $id ]['hook'],
+				array( $this, 'metabox_callback' ),
+				self::$props[ $this->id ]['hook'],
 				$box->meta_box['context'],
 				$box->meta_box['priority']
 			);
@@ -687,7 +672,6 @@ class Cmb2_Metatabs_Options {
 	 * Mimics the CMB2 "should show" function to prevent boxes which should not be shown on this options page from
 	 * appearing.
 	 *
-	 * @param string $id @since 1.1.0
 	 * @param CMB2   $box
 	 *
 	 * @return bool
@@ -695,7 +679,7 @@ class Cmb2_Metatabs_Options {
 	 * @since 1.1.0 Fixed bug with key vs page
 	 * @since 1.0.0
 	 */
-	private function should_show( $box, $id ) {
+	private function should_show( $box ) {
 		
 		// if the show_on key is not set, don't show
 		if ( ! isset( $box->meta_box['show_on']['key'] ) ) {
@@ -708,7 +692,7 @@ class Cmb2_Metatabs_Options {
 		}
 		
 		// if this options key is not in the show_on value, don't show
-		if ( ! in_array( self::$props[ $id ]['page'], $box->meta_box['show_on']['value'] ) ) {
+		if ( ! in_array( self::$props[ $this->id ]['page'], $box->meta_box['show_on']['value'] ) ) {
 			return FALSE;
 		}
 		
@@ -750,36 +734,35 @@ class Cmb2_Metatabs_Options {
 	/**
 	 * Triggers the loading of our metaboxes on this screen.
 	 *
-	 * @param string $id @since 1.1.0
+	 * @param string $this->id @since 1.1.0
 	 *
 	 * @since 1.0.0
 	 */
-	public function do_metaboxes( $id ) {
+	public function do_metaboxes() {
 		
-		do_action( 'add_meta_boxes_' . self::$props[ $id ]['hook'], NULL );
-		do_action( 'add_meta_boxes', self::$props[ $id ]['hook'], NULL );
+		do_action( 'add_meta_boxes_' . self::$props[ $this->id ]['hook'], NULL );
+		do_action( 'add_meta_boxes', self::$props[ $this->id ]['hook'], NULL );
 	}
 	
 	/**
 	 * Builds the fields and saves them.
 	 *
 	 * @param array  $args @since 1.1.0
-	 * @param string $id   @since 1.1.0
 	 *
 	 * @since 1.0.1 Refactored the save tests to method should_save()
 	 * @since 1.0.0
 	 */
-	public function metabox_callback( $args, $id ) {
+	public function metabox_callback( $post, $metabox ) {
 		
 		// get the metabox, fishing the ID out of the arguments array
-		$cmb = cmb2_get_metabox( $args[1]['id'], self::$props[ $id ]['key'] );
+		$cmb = cmb2_get_metabox( $metabox['id'], self::$props[ $this->id ]['key'] );
 		
-		if ( $this->should_save( $cmb, $id ) ) {
+		if ( $this->should_save( $cmb ) ) {
 			// save fields
-			$cmb->save_fields( self::$props[ $id ]['key'], $cmb->mb_object_type(), $_POST );
-		} else if ( $this->should_reset( $cmb, $id ) ) {
+			$cmb->save_fields( self::$props[ $this->id ]['key'], $cmb->mb_object_type(), $_POST );
+		} else if ( $this->should_reset( $cmb ) ) {
 			// Reset fields
-			delete_option( self::$props[ $id ]['key'] );
+			delete_option( self::$props[ $this->id ]['key'] );
 		}
 		
 		// show the fields
@@ -790,7 +773,7 @@ class Cmb2_Metatabs_Options {
 	 * Determine whether the CMB2 object should be reset. All tests must be true, hence return false for
 	 * any failure.
 	 *
-	 * @param string $id @since 1.1.0
+	 * @param string $this->id @since 1.1.0
 	 * @param \CMB2  $cmb
 	 *
 	 * @return bool
@@ -799,7 +782,7 @@ class Cmb2_Metatabs_Options {
 	 * @since 1.0.3 made static method
 	 * @since 1.0.1
 	 */
-	private function should_reset( $cmb, $id ) {
+	private function should_reset( $cmb ) {
 		
 		// are these values set?
 		if ( ! isset( $_POST['reset-cmb'], $_POST['object_id'], $_POST[ $cmb->nonce() ] ) ) {
@@ -812,7 +795,7 @@ class Cmb2_Metatabs_Options {
 		}
 		
 		// does the object_id equal the settings key?
-		if ( ! $_POST['object_id'] == self::$props[ $id ]['key'] ) {
+		if ( ! $_POST['object_id'] == self::$props[ $this->id ]['key'] ) {
 			return FALSE;
 		}
 		
@@ -823,7 +806,6 @@ class Cmb2_Metatabs_Options {
 	 * Determine whether the CMB2 object should be saved. All tests must be true, hence return false for
 	 * any failure.
 	 *
-	 * @param string $id @since 1.1.0
 	 * @param \CMB2  $cmb
 	 *
 	 * @return bool
@@ -832,7 +814,7 @@ class Cmb2_Metatabs_Options {
 	 * @since 1.0.3 made static method
 	 * @since 1.0.1
 	 */
-	private function should_save( $cmb, $id ) {
+	private function should_save( $cmb ) {
 		
 		// was this flagged to save fields?
 		if ( ! $cmb->prop( 'save_fields' ) ) {
@@ -850,7 +832,7 @@ class Cmb2_Metatabs_Options {
 		}
 		
 		// does the object_id equal the settings key?
-		if ( ! $_POST['object_id'] == self::$props[ $id ]['key'] ) {
+		if ( ! $_POST['object_id'] == self::$props[ $this->id ]['key'] ) {
 			return FALSE;
 		}
 		
@@ -860,37 +842,35 @@ class Cmb2_Metatabs_Options {
 	/**
 	 * Admin page markup.
 	 *
-	 * @param string $id @since 1.1.0
-	 *
 	 * @since 1.2   Checks user's capabilities to view page
 	 * @since 1.1.0 Added page identifier to filters for easier multiple-page use
 	 *              - Moved page part compilers to separate functions for clarity
 	 * @since 1.0.0
 	 */
-	public function admin_page_display( $id ) {
+	public function admin_page_display() {
 		
 		// this is only set to true if a menu sub-item has the same slug as the parent
-		if ( self::$props[ $id ]['hide'] ) {
+		if ( self::$props[ $this->id ]['hide'] ) {
 			return;
 		}
 		
 		// check page viewing capability
-		if ( self::$props[ $id ]['menuargs']['view_capability'] !== FALSE ) {
-			if ( ! current_user_can( self::$props[ $id ]['menuargs']['view_capability'] ) ) {
+		if ( self::$props[ $this->id ]['menuargs']['view_capability'] !== FALSE ) {
+			if ( ! current_user_can( self::$props[ $this->id ]['menuargs']['view_capability'] ) ) {
 				return;
 			}
 		}
 		
 		// get top of page
-		$page = $this->admin_page_top( $id );
+		$page = $this->admin_page_top( $this->id );
 		
 		// if there are metaboxes to display, add form and boxes
-		if ( ! empty( self::$props[ $id ]['boxes'] ) ) {
-			$page .= $this->admin_page_form( $id );
+		if ( ! empty( self::$props[ $this->id ]['boxes'] ) ) {
+			$page .= $this->admin_page_form( $this->id );
 		}
 		
 		// get bottom of page
-		$page .= $this->admin_page_bottom( $id );
+		$page .= $this->admin_page_bottom( $this->id );
 		
 		echo $page;
 		
@@ -901,23 +881,21 @@ class Cmb2_Metatabs_Options {
 	/**
 	 * Generates the top of the options page
 	 *
-	 * @param $id
-	 *
 	 * @return string
 	 *
 	 * @since 1.1.2 Instead of passing empty string directly in filter call, set it to var; allows cumulative filters
 	 * @since 1.1.1  added ability to inject extra wrapper class(es)
 	 * @since 1.1.0
 	 */
-	private function admin_page_top( $id ) {
+	private function admin_page_top() {
 		
 		// standard classes, includes page id
-		$classes    = 'wrap cmb2-options-page cmo-options-page ' . self::$props[ $id ]['page'];
+		$classes    = 'wrap cmb2-options-page cmo-options-page ' . self::$props[ $this->id ]['page'];
 		$filterable = '';
 		
 		// add any extra configured classes
-		if ( ! empty( self::$props[ $id ]['class'] ) ) {
-			$classes .= ' ' . self::$props[ $id ]['class'];
+		if ( ! empty( self::$props[ $this->id ]['class'] ) ) {
+			$classes .= ' ' . self::$props[ $this->id ]['class'];
 		}
 		
 		$ret = '<div class="' . $classes . '">';
@@ -925,7 +903,7 @@ class Cmb2_Metatabs_Options {
 		$ret .= '<div class="cmo-before-form">';
 		
 		// note this now passes the page slug as a second argument
-		$ret .= apply_filters( 'cmb2metatabs_before_form', $filterable, self::$props[ $id ]['page'] );
+		$ret .= apply_filters( 'cmb2metatabs_before_form', $filterable, self::$props[ $this->id ]['page'] );
 		
 		$ret .= '</div>';
 		
@@ -935,21 +913,21 @@ class Cmb2_Metatabs_Options {
 	/**
 	 * Generate bottom of options page
 	 *
-	 * @param $id
+	 * @param $this->id
 	 *
 	 * @return string
 	 *
 	 * @since 1.1.2 Instead of passing empty string directly in filter call, set it to var; allows cumulative filters
 	 * @since 1.1.0
 	 */
-	private function admin_page_bottom( $id ) {
+	private function admin_page_bottom() {
 		
 		$filterable = '';
 		
 		$ret = '<div class="cmo-after-form">';
 		
 		// note this now passes the page slug as a second argument
-		$ret .= apply_filters( 'cmb2metatabs_after_form', $filterable, self::$props[ $id ]['page'] );
+		$ret .= apply_filters( 'cmb2metatabs_after_form', $filterable, self::$props[ $this->id ]['page'] );
 		
 		$ret .= '</div>';
 		$ret .= '</div>';
@@ -960,21 +938,19 @@ class Cmb2_Metatabs_Options {
 	/**
 	 * Metaboxes and tabs display on options page
 	 *
-	 * @param string $id
-	 *
 	 * @return string
 	 *
 	 * @since 1.2   Added WP nonces for box order and closed boxes
 	 * @since 1.1.0 Moved admin page form to separate function to allow text-only options pages
 	 */
-	private function admin_page_form( $id ) {
+	private function admin_page_form() {
 		
 		// form wraps all tabs
 		$ret = '<form class="cmb-form" method="post" id="cmo-options-form" '
 		       . 'enctype="multipart/form-data" encoding="multipart/form-data">';
 		
 		// hidden object_id field
-		$ret .= '<input type="hidden" name="object_id" value="' . self::$props[ $id ]['key'] . '">';
+		$ret .= '<input type="hidden" name="object_id" value="' . self::$props[ $this->id ]['key'] . '">';
 		
 		// wp nonce fields
 		$ret .= wp_nonce_field( 'meta-box-order', 'meta-box-order-nonce', FALSE, FALSE );
@@ -984,10 +960,10 @@ class Cmb2_Metatabs_Options {
 		$ret .= '<div id="poststuff">';
 		
 		// main column
-		$ret .= '<div id="post-body" class="metabox-holder columns-' . self::$props[ $id ]['cols'] . '">';
+		$ret .= '<div id="post-body" class="metabox-holder columns-' . self::$props[ $this->id ]['cols'] . '">';
 		
 		// if two columns are called for
-		if ( self::$props[ $id ]['cols'] == 2 ) {
+		if ( self::$props[ $this->id ]['cols'] == 2 ) {
 			
 			// add markup for sidebar
 			$ret .= '<div id="postbox-container-1" class="postbox-container">';
@@ -996,7 +972,7 @@ class Cmb2_Metatabs_Options {
 			ob_start();
 			
 			// add sidebar metaboxes
-			do_meta_boxes( self::$props[ $id ]['hook'], 'side', NULL );
+			do_meta_boxes( self::$props[ $this->id ]['hook'], 'side', NULL );
 			
 			$ret .= ob_get_clean();
 			
@@ -1005,27 +981,27 @@ class Cmb2_Metatabs_Options {
 		
 		// open postbox container
 		$ret .= '<div id="postbox-container-';
-		$ret .= self::$props[ $id ]['cols'] == 2 ? '2' : '1';
+		$ret .= self::$props[ $this->id ]['cols'] == 2 ? '2' : '1';
 		$ret .= '" class="postbox-container">';
 		
 		// add tabs; the sortables container is within each tab
-		$ret .= $this->render_tabs( $id );
+		$ret .= $this->render_tabs( $this->id );
 		
 		ob_start();
 		
 		// place normal boxes, note that 'normal' and 'advanced' are rendered together when using tabs
-		do_meta_boxes( self::$props[ $id ]['hook'], 'normal', NULL );
-		do_meta_boxes( self::$props[ $id ]['hook'], 'advanced', NULL );
+		do_meta_boxes( self::$props[ $this->id ]['hook'], 'normal', NULL );
+		do_meta_boxes( self::$props[ $this->id ]['hook'], 'advanced', NULL );
 		
 		$ret .= ob_get_clean();
 		
 		$ret .= '</div></div></div>';
 		
 		// add submit button if resettxt or savetxt was included
-		if ( self::$props[ $id ]['resettxt'] || self::$props[ $id ]['savetxt'] ) {
+		if ( self::$props[ $this->id ]['resettxt'] || self::$props[ $this->id ]['savetxt'] ) {
 			$ret .= '<div style="clear:both;">';
-			$ret .= $this->render_reset_button( self::$props[ $id ]['resettxt'] );
-			$ret .= $this->render_save_button( self::$props[ $id ]['savetxt'] );
+			$ret .= $this->render_reset_button( self::$props[ $this->id ]['resettxt'] );
+			$ret .= $this->render_save_button( self::$props[ $this->id ]['savetxt'] );
 			$ret .= '</div>';
 		}
 		
@@ -1064,22 +1040,19 @@ class Cmb2_Metatabs_Options {
 	/**
 	 * Added a check to make sure its only called once for the page...
 	 *
-	 * @param array  $args @since 1.1.0
-	 * @param string $id   @since 1.1.0
-	 *
 	 * @since 1.0.1 updated text domain
 	 * @since 1.0.0
 	 */
-	public function settings_notices( $args, $id ) {
+	public function settings_notices( $object_id, $cmb_id ) {
 		
 		// bail if this isn't a notice for this page or we've already added a notice
-		if ( $args[0] !== self::$props[ $id ]['key'] || empty( $args[1] ) || self::$once ) {
+		if ( $object_id !== self::$props[ $this->id ]['key'] || empty( $cmb_id ) || self::$once ) {
 			return;
 		}
 		
 		// add notifications
-		add_settings_error( self::$props[ $id ]['key'] . '-notices', '', __( 'Settings updated.', 'cmb2' ), 'updated' );
-		settings_errors( self::$props[ $id ]['key'] . '-notices' );
+		add_settings_error( self::$props[ $this->id ]['key'] . '-notices', '', __( 'Settings updated.', 'cmb2' ), 'updated' );
+		settings_errors( self::$props[ $this->id ]['key'] . '-notices' );
 		
 		// set the flag so we don't pile up notices
 		self::$once = TRUE;
@@ -1088,22 +1061,20 @@ class Cmb2_Metatabs_Options {
 	/**
 	 * Returns tabs, if they've been configured.
 	 *
-	 * @param string $id @since 1.1.0
-	 *
 	 * @return string $return
 	 *
 	 * @since 1.0.0
 	 */
-	private function render_tabs( $id ) {
+	private function render_tabs() {
 		
-		if ( empty( self::$props[ $id ]['tabs'] ) ) {
+		if ( empty( self::$props[ $this->id ]['tabs'] ) ) {
 			return '';
 		}
 		
 		$containers = '';
 		$tabs       = '';
 		
-		foreach ( self::$props[ $id ]['tabs'] as $tab ) {
+		foreach ( self::$props[ $this->id ]['tabs'] as $tab ) {
 			
 			// add tabs navigation
 			$tabs .= '<a href="#" id="opt-tab-' . $tab['id'] . '" class="nav-tab opt-tab" ';
@@ -1139,7 +1110,7 @@ class Cmb2_Metatabs_Options {
 	 * 2) Add additional boxes (or boxes if none were injected) the usual way within this function
 	 * 3) If array is still empty and getboxes === true, call CMB2_Boxes::get_all();
 	 *
-	 * @param string $id @since 1.1.0
+	 * @param string $this->id @since 1.1.0
 	 *
 	 * @return array|\CMB2[]
 	 *
@@ -1147,10 +1118,10 @@ class Cmb2_Metatabs_Options {
 	 *              - ok to pass CMB2 metabox ID or CMB2 object; previously only objects allowed
 	 * @since 1.0.0
 	 */
-	private function cmb2_metaboxes( $id ) {
+	private function cmb2_metaboxes() {
 		
 		// add any injected metaboxes
-		$boxes = self::$props[ $id ]['boxes'];
+		$boxes = self::$props[ $this->id ]['boxes'];
 		
 		// if boxes is not empty, check to see if they're CMB2 objects, or strings
 		if ( ! empty( $boxes ) ) {
@@ -1162,7 +1133,7 @@ class Cmb2_Metatabs_Options {
 		}
 		
 		// if $boxes is still empty and getboxes is true, try grabbing boxes from CMB2
-		$boxes = ( empty( $boxes ) && self::$props[ $id ]['getboxes'] === TRUE ) ? CMB2_Boxes::get_all() : $boxes;
+		$boxes = ( empty( $boxes ) && self::$props[ $this->id ]['getboxes'] === TRUE ) ? CMB2_Boxes::get_all() : $boxes;
 		
 		return $boxes;
 	}
@@ -1171,15 +1142,15 @@ class Cmb2_Metatabs_Options {
 	 * Add tabs to your options page. The array is empty by default. You can inject them into the constructor,
 	 * or add them here, or leave empty for no tabs.
 	 *
-	 * @param string $id @since 1.1.0
+	 * @param string $this->id @since 1.1.0
 	 *
 	 * @return array
 	 *
 	 * @since 1.0.0
 	 */
-	private function add_tabs( $id ) {
+	private function add_tabs() {
 		
-		$tabs = self::$props[ $id ]['tabs'];
+		$tabs = self::$props[ $this->id ]['tabs'];
 		
 		return $tabs;
 	}

--- a/code/cmb2_metatabs_options.php
+++ b/code/cmb2_metatabs_options.php
@@ -3,6 +3,15 @@
 /**
  * See https://github.com/rogerlos/cmb2-metatabs-options
  *
+ * GamiPress Team updates:
+ *
+ * Support to CMB2 2.7.0 by renaming CMB2_hookup instances to CMB2_Hookup
+ * Support for PHP 5.6:
+ * - Moved auto-generated id into a object var
+ * - Removed all usages of [] to instantiate arrays
+ * - Moved all direct callbacks into a reference calls
+ * On multisite installs, fixed undefined 'hook' index
+ *
  * General Notes
  *
  * @since 1.3   Adds reset options button, thanks @rubengc https://github.com/rubengc
@@ -398,7 +407,7 @@ class Cmb2_Metatabs_Options {
 		// Include CMB CSS in the head to avoid FOUC, called here as we need the screen ID
 		add_action(
 			'admin_print_styles-' . self::$props[ $this->id ]['hook'],
-			array( 'CMB2_hookup', 'enqueue_cmb_css' )
+			array( 'CMB2_Hookup', 'enqueue_cmb_css' )
 		);
 		
 		// Adds existing metaboxes, see note in function, called here as we need the screen ID
@@ -505,6 +514,10 @@ class Cmb2_Metatabs_Options {
 	public function add_scripts() {
 		
 		global $hook_suffix;
+
+		if( ! isset( self::$props[ $this->id ]['hook'] ) ) {
+			return;
+		}
 		
 		// do not run if not a CMO page
 		if ( $hook_suffix !== self::$props[ $this->id ]['hook'] ) {


### PR DESCRIPTION
Moved auto-generated id into a object var
Removed all usages of [] to instantiate arrays
Moved all direct callbacks into a reference calls
Support with php 5.6 tested and working